### PR TITLE
Defect#1203615

### DIFF
--- a/src/com/ppm/integration/agilesdk/connector/jira/cloud/JIRACloudIntegrationConnector.java
+++ b/src/com/ppm/integration/agilesdk/connector/jira/cloud/JIRACloudIntegrationConnector.java
@@ -128,6 +128,8 @@ public class JIRACloudIntegrationConnector extends IntegrationConnector {
             AgileProject agileProject = new AgileProject();
             agileProject.setDisplayName(jiraProject.getName());
             agileProject.setValue(jiraProject.getKey());
+            agileProject.setCompanyManagedProject(jiraProject.isCompanyMangedProject());
+            agileProject.setAgileProjectId(jiraProject.getJiraProjectId());
             agileProjects.add(agileProject);
         }
 

--- a/src/com/ppm/integration/agilesdk/connector/jira/cloud/JIRACloudPortfolioEpicIntegration.java
+++ b/src/com/ppm/integration/agilesdk/connector/jira/cloud/JIRACloudPortfolioEpicIntegration.java
@@ -29,10 +29,10 @@ public class JIRACloudPortfolioEpicIntegration extends PortfolioEpicIntegration 
     // All operations for Portfolio Epics are using the admin account as users are not prompted for account info upon sync.
 
 
-    @Override public String createEpicInAgileProject(PortfolioEpicCreationInfo epicInfo, String agileProjectValue,
+    @Override public String createEpicInAgileProject(PortfolioEpicCreationInfo epicInfo, String agileProjectValue, boolean isCompanyMangedProject, long agileProjectId,
             ValueSet instanceConfigurationParameters)
     {
-        return JIRAServiceProvider.get(instanceConfigurationParameters).createEpic(agileProjectValue, epicInfo.getEpicName(), epicInfo.getEpicDescription());
+        return JIRAServiceProvider.get(instanceConfigurationParameters).createEpic(agileProjectValue, isCompanyMangedProject, agileProjectId, epicInfo.getEpicName(), epicInfo.getEpicDescription());
     }
 
     @Override public PortfolioEpicSyncInfo getPortfolioEpicSyncInfo(String epicId, String agileProjectValue,

--- a/src/com/ppm/integration/agilesdk/connector/jira/cloud/JIRAConstants.java
+++ b/src/com/ppm/integration/agilesdk/connector/jira/cloud/JIRAConstants.java
@@ -185,6 +185,8 @@ public class JIRAConstants {
     public static final String JIRA_EPIC_LINK_CUSTOM = "com.pyxis.greenhopper.jira:gh-epic-link";
 
     public static final String JIRA_EPIC_NAME_CUSTOM = "com.pyxis.greenhopper.jira:gh-epic-label";
+    
+    public static final String JIRA_EPIC_NAME_IN_TEAM_MANAGED_PROJECT = "Epic Name";
 
     public static final String JIRA_PORTFOLIO_PARENT_CUSTOM =  "com.atlassian.jpo:jpo-custom-field-parent";
 


### PR DESCRIPTION
create epic in jira cloud error in team-managed projects
root cause: epic name is a customized field in team managed projects, the field name of epic name is vary in different projects in team managed projects.
solution: get the field name for team-managed projects for each team managed project