### PR TITLE
Defect#1202846EmptySprintsMigrated

### DIFF
--- a/src/com/ppm/integration/agilesdk/connector/jira/cloud/JIRACloudWorkPlanIntegration.java
+++ b/src/com/ppm/integration/agilesdk/connector/jira/cloud/JIRACloudWorkPlanIntegration.java
@@ -715,6 +715,8 @@ public class JIRACloudWorkPlanIntegration extends WorkPlanIntegration {
                     }
                     sprintIssues.add(issue);
                 }
+                
+                cleanEmptySprints(issuesBySprintId);
 
                 for (final String sprintId : issuesBySprintId.keySet()) {
 
@@ -947,6 +949,19 @@ public class JIRACloudWorkPlanIntegration extends WorkPlanIntegration {
                 }
             }
         };
+    }
+    
+    private void cleanEmptySprints(final Map<String, List<JIRASubTaskableIssue>> issuesBySprintId) {
+    	List<String> removedSprints = new ArrayList<String>();
+    	for (final String sprintId : issuesBySprintId.keySet()) {
+    		List<JIRASubTaskableIssue> sprintIssues = issuesBySprintId.get(sprintId);
+    		if (sprintIssues.size() == 0) {
+    			removedSprints.add(sprintId);
+    		}
+    	}
+    	for (final String sprintId: removedSprints) {
+    		issuesBySprintId.remove(sprintId);
+        }
     }
 
     @Override


### PR DESCRIPTION
Customer reported this defect. Sync ppm task with issues under a specific epic group by sprints. The sprints don't have the related issues are also synchronized to ppm task. If empty sprints synchronized to ppm task, the task cannot be closed unless all these unrelated sprints are closed.
Do not retrieve sprints which don't contain any issues. 