### PR TITLE
ER#1878339 Migration of Search Request APIs to Updated Endpoints

### DIFF
--- a/src/com/ppm/integration/agilesdk/connector/jira/cloud/JIRAConstants.java
+++ b/src/com/ppm/integration/agilesdk/connector/jira/cloud/JIRAConstants.java
@@ -115,6 +115,8 @@ public class JIRAConstants {
 
     public static final String API_VERSION2_API_ROOT = "/rest/api/2/";
 
+    public static final String API_VERSION3_API_ROOT = "/rest/api/3/";
+
     public static final String PORTFOLIO_HIERARCHY_REST = "/rest/jpo-api/1.0/hierarchy";
 
     public static final String SEARCH_USER = API_VERSION2_API_ROOT + "user/search";

--- a/src/com/ppm/integration/agilesdk/connector/jira/cloud/model/IssueRetrievalResult.java
+++ b/src/com/ppm/integration/agilesdk/connector/jira/cloud/model/IssueRetrievalResult.java
@@ -13,16 +13,10 @@ public class IssueRetrievalResult {
 
     private List<JSONObject> issues = new ArrayList<>();
 
-    private int startAt;
+    private  String  nextPageToken;
 
-    private int maxResults;
-
-    private int total;
-
-    public IssueRetrievalResult(int startAt, int maxResults, int total) {
-        this.startAt = startAt;
-        this.maxResults = maxResults;
-        this.total = total;
+    public IssueRetrievalResult(String nextPageToken) {
+      this.nextPageToken = nextPageToken;
     }
 
     public List<JSONObject> getIssues() {
@@ -33,15 +27,8 @@ public class IssueRetrievalResult {
         issues.add(issue);
     }
 
-    public int getStartAt() {
-        return startAt;
+    public String getNextPageToken() {
+        return nextPageToken;
     }
 
-    public int getMaxResults() {
-        return maxResults;
-    }
-
-    public int getTotal() {
-        return total;
-    }
 }

--- a/src/com/ppm/integration/agilesdk/connector/jira/cloud/util/JiraIssuesRetrieverUrlBuilder.java
+++ b/src/com/ppm/integration/agilesdk/connector/jira/cloud/util/JiraIssuesRetrieverUrlBuilder.java
@@ -23,7 +23,7 @@ public class JiraIssuesRetrieverUrlBuilder {
 
     private int maxResults = 1000;
 
-    private int startAt = 0;
+    private String nextPageToken = null;
 
     private String boardId;
 
@@ -101,7 +101,7 @@ public class JiraIssuesRetrieverUrlBuilder {
                 searchUrl.append(JIRAConstants.BOARD_SUFFIX + "/" + boardId + "/issue?");
                 break;
             default: // SEARCH
-                searchUrl.append(JIRAConstants.API_VERSION2_API_ROOT + "search?");
+                searchUrl.append(JIRAConstants.API_VERSION3_API_ROOT + "search/jql?");
         }
 
 
@@ -111,7 +111,9 @@ public class JiraIssuesRetrieverUrlBuilder {
             urlParameters.add("maxResults=" + maxResults);
         }
 
-        urlParameters.add("startAt=" + startAt);
+        if(nextPageToken != null){
+            urlParameters.add("nextPageToken=" + nextPageToken);
+        }
 
         if (!StringUtils.isBlank(expandLevel)) {
             urlParameters.add("expand=" + expandLevel);
@@ -242,8 +244,8 @@ public class JiraIssuesRetrieverUrlBuilder {
         return this;
     }
 
-    public void setStartAt(int startAt) {
-        this.startAt = startAt;
+    public void setNextPageToken(String nextPageToken) {
+        this.nextPageToken = nextPageToken;
     }
 
     // The OR constraints will be added next to all the AND constraints.


### PR DESCRIPTION
**Issue:**
PPM request creation and updation failed for connector due to a 410 Gone response from Jira.
The error message indicated that the old endpoint /rest/api/2/search was deprecated and removed.

**Error  Response from Jira :**
 {"errorMessages":["The requested API has been removed. Please migrate to the /rest/api/3/search/jql API. A full migration guideline is available at https://developer.atlassian.com/changelog/#CHANGE-2046   "],"errors":{}}


**Fix:**
1.Updated API calls from /rest/api/2/search → /rest/api/3/search/jql.
2.Adjusted query parameters as per the new endpoint specification.

**Outcome:**
PPM request creation and updation now works successfully with the new Jira Cloud search API.